### PR TITLE
Implement deep link handling for password reset

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { Text } from "react-native";
 import * as Linking from "expo-linking";
-import { NavigationContainer } from "@react-navigation/native";
+import {
+  NavigationContainer,
+  NavigationContainerRef,
+  ParamListBase,
+} from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { Provider as PaperProvider } from "react-native-paper";
 
@@ -33,10 +37,28 @@ const linking = {
   },
 };
 
+const navigationRef = React.useRef<NavigationContainerRef<ParamListBase>>(null);
+
 export default function App() {
+  React.useEffect(() => {
+    const handleDeepLink = ({ url }: { url: string }) => {
+      const data = Linking.parse(url);
+      if (data.path === "reset-password") {
+        navigationRef.current?.navigate("PantallaCambiarContrasena", { url });
+      }
+    };
+
+    const sub = Linking.addEventListener("url", handleDeepLink);
+    return () => sub.remove();
+  }, []);
+
   return (
     <PaperProvider>
-      <NavigationContainer linking={linking} fallback={<Text>Cargando…</Text>}>
+      <NavigationContainer
+        ref={navigationRef}
+        linking={linking}
+        fallback={<Text>Cargando…</Text>}
+      >
         <Stack.Navigator initialRouteName="PantallaIniciarSesion" screenOptions={{ headerShown: false }}>
           {/* Flujo contraseña */}
           <Stack.Screen name="PantallaRecuperarContrasena" component={PantallaRecuperarContrasena} />

--- a/Pantallas/PantallaCambiarContrasena.tsx
+++ b/Pantallas/PantallaCambiarContrasena.tsx
@@ -20,7 +20,7 @@ import { supabase } from "../supabaseClient";
 
 const { width } = Dimensions.get("window");
 
-export default function PantallaCambiarContrasena({ navigation }: any) {
+export default function PantallaCambiarContrasena({ route, navigation }: any) {
   const [password, setPassword] = useState("");
   const [confirm, setConfirm]   = useState("");
   const [error, setError]       = useState("");
@@ -28,12 +28,14 @@ export default function PantallaCambiarContrasena({ navigation }: any) {
 
   useEffect(() => {
     (async () => {
-      // 1) Capturo la URL que abrió la app
-      const url = await Linking.getInitialURL();
+      const url = route.params?.url;
       console.log("Deep link recibido:", url);
 
-      // 2) La paso a Supabase para extraer el token y guardar la sesión
-      //    (casteo a any porque TS no reconoce el método en tu versión)
+      if (!url) {
+        navigation.replace("PantallaIniciarSesion");
+        return;
+      }
+
       const { error } = await (supabase.auth as any).getSessionFromUrl({
         storeSession: true,
         url,
@@ -42,9 +44,8 @@ export default function PantallaCambiarContrasena({ navigation }: any) {
         console.warn("Link inválido o expirado:", error.message);
         navigation.replace("PantallaIniciarSesion");
       }
-      // si no hay error, la sesión quedó almacenada y mostramos el formulario
     })();
-  }, []);
+  }, [route.params?.url]);
 
   const handleUpdate = async () => {
     setError("");

--- a/Pantallas/PantallaRecuperarContrasena.tsx
+++ b/Pantallas/PantallaRecuperarContrasena.tsx
@@ -8,6 +8,7 @@ import * as Linking from "expo-linking";
 import { supabase } from "../supabaseClient";
 
 const { width } = Dimensions.get("window");
+const RESET_PASSWORD_URL = Linking.createURL("reset-password");
 
 export default function PantallaRecuperarContrasena({ navigation }: any) {
   const [email, setEmail] = useState("");
@@ -37,9 +38,9 @@ export default function PantallaRecuperarContrasena({ navigation }: any) {
     }
 
     setLoading(true);
-    // Generamos el deep link dinámicamente
-    const redirectUrl = Linking.createURL("reset-password");
-    const { error: resetErr } = await supabase.auth.resetPasswordForEmail(email, { redirectTo: redirectUrl });
+    const { error: resetErr } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: RESET_PASSWORD_URL,
+    });
     setLoading(false);
 
     if (resetErr) {


### PR DESCRIPTION
## Summary
- listen for incoming deep links in App.tsx and navigate when a reset password link arrives
- load the reset password URL from navigation params in `PantallaCambiarContrasena`
- use a constant for the reset password redirect URL in `PantallaRecuperarContrasena`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863443404508328b1931451c127b762